### PR TITLE
WADS-1016:  Fork dompdf for PHP74 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dompdf/dompdf",
+    "name": "uofa/dompdf",
     "type": "library",
     "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
     "homepage": "https://github.com/dompdf/dompdf",

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -2542,7 +2542,7 @@ EOT;
                             $width = floatval($dtmp['WX']);
 
                             if ($c >= 0) {
-                                if ($c != hexdec($n)) {
+                                if (ctype_xdigit($c) && ctype_xdigit($n)) {
                                     $data['codeToName'][$c] = $n;
                                 }
                                 $data['C'][$c] = $width;

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -2542,7 +2542,7 @@ EOT;
                             $width = floatval($dtmp['WX']);
 
                             if ($c >= 0) {
-                                if (ctype_xdigit($c) && ctype_xdigit($n)) {
+                                if (ctype_xdigit($c) && ctype_xdigit($n) && $c != hexdec($n)) {
                                     $data['codeToName'][$c] = $n;
                                 }
                                 $data['C'][$c] = $width;


### PR DESCRIPTION
## Overview of Change

This fork has been created as an interim measure while we have to support PHP5.6 and PHP74. 

dompdf version 0.8.3 is the last version of the library that is compatible with PHP56.   However, the 0.8.3 version breaks under PHP7.4 due to a change in the way PHPs built-in hexdec() handles invalid characters.  Hexdec() now raises a [deprecation error in PHP74](https://www.php.net/manual/en/migration74.deprecated.php). 

[A patch has been applied](https://github.com/dompdf/dompdf/pull/2027/files) to the upstream version 0.8.4 version of dompdf, however, this version does not support PHP 5.6.  The fix has been backported to this (UofA) fork in order to maintain compatibility with PHP5.6 and PHP7.4.

This dompdf [GitHub Issue #2003](https://github.com/dompdf/dompdf/issues/2003) discusses the bug.

```
development.ERROR: ErrorException: Invalid characters passed for attempted conversion, these have been ignored in /home/web-a/wdu126/laravel/vendor/dompdf/dompdf/lib/Cpdf.php:2545
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 /home/web-a/wdu126/laravel/vendor/dompdf/dompdf/lib/Cpdf.php(2545): hexdec()
```


## Motivation and Context
This change is part of the WADS PHP74 upgrade work.


## How has this been Tested?
Changes have been tested locally using both PHP5.6 and PHP7.4.

The fork has been used in ePayments and PDF generation has been tested in the development environments for both PHP versions.  Please [see this PR](https://github.com/uofa/epayments/pull/309).


## Environments
N/A


## Dependencies
N/A


## Test Instructions

Testing can be carried out using ePayments, please [see this PR](https://github.com/uofa/epayments/pull/309).

## Test Instructions

1. Testing should be carried out in the [staging](https://staging.abdn.ac.uk/csd/epayments-dev/login) and [staging2](https://staging2.abdn.ac.uk/csd/epayments-dev/login) environments (php56 and PHP74 respectively).
2. After creating a Direct Debit. ensure that you can download and view the PDF Direct Debit Mandate presented in Step 8 (Confirmation of Payment Plan application) and that all details are correct. 
3. Open `laravel/vendor/uofa/dompdf/lib/Cpdf.php`
4. Change line 2545 from `if (ctype_xdigit($c) && ctype_xdigit($n) && $c != hexdec($n)) {` to `if ($c != hexdec($n)) {`
5. Create a Direct Debit and attempt to download the PDF.  Confirm that `laravel/logs` contains the following error:

```sh
development.ERROR: ErrorException: Invalid characters passed for attempted conversion, these have been ignored in laravel/vendor/dompdf/dompdf/lib/Cpdf.php:2545
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 laravel/vendor/dompdf/dompdf/lib/Cpdf.php(2545): hexdec()
```
6. Revert the change made in step 5

## Deployment Instructions
<!-- Provide detailed, ordered deployment instructions, explaining how to depoy -->
<!-- these changes specifically to the production environment. -->


## Checklist
<!-- Review the statements below and put an `x` in all that are applicable. -->
<!-- If you have not completed a step that is applicable, please indicate -->
<!-- why this is the case below. This is important for quality control. -->
- [x] This code follows the Coding Standards set for this project.
- [ ] Automated tests have been updated as required.
- [ ] All applicable automated tests are passing.
- [ ] UAT / sign-off is required for this PR.
- [ ] An RFC is required for this change to be deployed to production.
- [ ] Documentation has been updated accordingly (where applicable).
